### PR TITLE
Schema is not provided for async config.

### DIFF
--- a/config/schema/adobe_analytics.schema.yml
+++ b/config/schema/adobe_analytics.schema.yml
@@ -50,6 +50,9 @@ adobe_analytics.settings:
     production_tag_manager_footer_js:
       type: string
       label: 'Production Tag manager footer js code'
+    async:
+      type: boolean
+      label: 'Asyncronous analytics loading'
     role_tracking_type:
       type: string
       label: 'Role Tracking Type'


### PR DESCRIPTION
Whilst there is configuration in the form(s) for asyncronous loading of analytics, the schema for this has not been added and as such Drupal's CI complains that the configuration once updated fails to match the modules schema.